### PR TITLE
Add CI light test mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm ci
       - run: npm run format:check
       - run: npm run lint
-      - run: npm test
+      - run: npm run test:ci

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker-compose run --rm goethe-b1
 # Process a single page
 PAGE=42 docker-compose --profile page run --rm goethe-b1-page
 
-# Run tests
+# Run tests (full suite)
 docker-compose --profile test run --rm goethe-b1-test
 ```
 
@@ -31,6 +31,8 @@ npm run process:page 42
 
 # Run tests
 npm test
+# Quick smoke tests (CI)
+npm run test:ci
 ```
 
 ## 📋 Overview
@@ -177,6 +179,7 @@ npm run clean               # Clean output directory
 
 # Testing & Quality
 npm test                    # Run test suite
+npm run test:ci             # Lighter tests for CI
 npm run lint               # Run ESLint
 npm run lint:fix           # Fix linting issues
 npm run format             # Format with Prettier

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "process:all": "node src/index.js --all",
     "process:page": "node src/index.js --page",
     "test": "node --test test/*.test.js",
+    "test:ci": "LIGHT_TESTS=1 node --test test/*.test.js",
     "clean": "rm -rf output/",
     "lint": "eslint src/ test/",
     "lint:fix": "eslint src/ test/ --fix",

--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,36 @@
-// Load environment variables
+/**
+ * Read an environment variable and provide a default value if it is not set.
+ *
+ * @param {string} name - Name of the variable to read.
+ * @param {string} [defaultValue=''] - Value returned when the variable is undefined.
+ * @returns {string} The value of the environment variable or the default.
+ */
 function getEnvVar(name, defaultValue = '') {
   return process.env[name] || defaultValue
 }
 
+/**
+ * Read a boolean environment variable.
+ *
+ * The variable is considered `true` when it exists and equals `"true"`
+ * case-insensitively.
+ *
+ * @param {string} name - Name of the variable to read.
+ * @param {boolean} [defaultValue=false] - Value returned when variable is undefined.
+ * @returns {boolean} Parsed boolean value.
+ */
 function getEnvBool(name, defaultValue = false) {
   const value = process.env[name]
   if (value === undefined) return defaultValue
   return value.toLowerCase() === 'true'
 }
 
+/**
+ * Global configuration object derived from environment variables.
+ *
+ * It defines page layout constants, default file paths and URLs as well
+ * as break-detection parameters used throughout the processing pipeline.
+ */
 export const CONFIG = {
   // Environment variables
   DEBUG: getEnvBool('DEBUG', false),
@@ -56,6 +78,12 @@ export const CONFIG = {
 }
 
 // Manual break overrides for specific pages
+/**
+ * Manual break overrides for problematic pages.
+ *
+ * The keys are "page-column" prefixes (e.g. "022-l") and each value is a
+ * set of Y coordinates where a break should be forced.
+ */
 export const BREAK_OVERRIDES = {
   '022-l': new Set([118]),
   '026-l': new Set([348]),

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import { promises as fs } from 'fs'
 import { cpus } from 'os'
+import { fileURLToPath } from 'url'
 import { CONFIG } from './config.js'
 import { PDFConverter } from './processors/pdf-converter.js'
 import { PageProcessor } from './processors/page-processor.js'
@@ -9,6 +10,9 @@ import { DataProcessor } from './processors/data-processor.js'
 import { fileExists } from './utils/fs.js'
 
 export class GoetheBrListProcessor {
+  /**
+   * Main orchestrator for processing the entire Wortliste.
+   */
   constructor() {
     this.pdfConverter = new PDFConverter()
     this.pageProcessor = new PageProcessor()
@@ -41,6 +45,11 @@ export class GoetheBrListProcessor {
   /**
    * Process the whole Wortliste (pages 16 – 102) in parallel.
    * Concurrency is capped at the number of detected CPU cores.
+   */
+  /**
+   * Process all pages of the PDF in parallel and generate combined outputs.
+   *
+   * @returns {Promise<void>}
    */
   async processAll() {
     console.log('Starting Goethe B1 Wortliste processing...')
@@ -94,6 +103,12 @@ export class GoetheBrListProcessor {
     console.log('Processing completed successfully!')
   }
 
+  /**
+   * Process a single page of the Wortliste.
+   *
+   * @param {number} pageNum - Page number to process.
+   * @returns {Promise<void>}
+   */
   async processPage(pageNum) {
     console.log(`Processing single page: ${pageNum}`)
 
@@ -113,6 +128,12 @@ export class GoetheBrListProcessor {
     console.log(`Page ${pageNum} processed successfully!`)
   }
 
+  /**
+   * Produce combined HTML and CSV outputs from aggregated data.
+   *
+   * @param {Array} allRawData - Raw entries from all pages.
+   * @returns {Promise<void>}
+   */
   async generateCombinedOutputs(allRawData) {
     const processedData = await this.dataProcessor.processExtractedData(allRawData)
     const html = await this.dataProcessor.generateHTML(processedData, 'all')
@@ -122,6 +143,9 @@ export class GoetheBrListProcessor {
     await fs.writeFile(`${CONFIG.OUTPUT_DIR}/all.csv`, csv)
   }
 
+  /**
+   * Print command-line usage instructions to stdout.
+   */
   showUsage() {
     console.log('Usage:')
     console.log('  node src/index.js --all              # Process all pages')
@@ -138,6 +162,9 @@ export class GoetheBrListProcessor {
   }
 }
 
+/**
+ * CLI entry point parsing arguments and invoking processors.
+ */
 async function main() {
   const args = process.argv.slice(2)
   const processor = new GoetheBrListProcessor()
@@ -173,4 +200,7 @@ process.on('unhandledRejection', err => {
   process.exit(1)
 })
 
-main().catch(console.error)
+const executedAsScript = process.argv[1] === fileURLToPath(import.meta.url)
+if (executedAsScript) {
+  main().catch(console.error)
+}

--- a/src/processors/break-detector.js
+++ b/src/processors/break-detector.js
@@ -3,6 +3,9 @@ import { BREAK_OVERRIDES, CONFIG } from '../config.js'
 import { padPageNumber } from '../utils/fs.js'
 
 export class BreakDetector {
+  /**
+   * Create a new break detector using configured threshold value.
+   */
   constructor() {
     this.threshold = CONFIG.BREAK_THRESHOLD
   }
@@ -80,6 +83,12 @@ export class BreakDetector {
   /**
    * Checks if a row of pixels is predominantly "white" (empty).
    * Assumes RGB or RGBA format.
+   *
+   * @param {Buffer} pixelBuffer - The raw pixel buffer.
+   * @param {number} rowIdx - Index of the row to check.
+   * @param {number} width - Width of the image in pixels.
+   * @param {number} channels - Number of color channels.
+   * @returns {boolean} True if the row is mostly white.
    */
   isRowEmpty(pixelBuffer, rowIdx, width, channels) {
     const rowStartOffset = rowIdx * width * channels

--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -3,8 +3,19 @@ import { spawn } from 'child_process'
 import { CONFIG } from '../config.js'
 
 export class DataProcessor {
+  /**
+   * Simple wrapper for processing raw and extracted data.
+   */
   constructor() {}
 
+  /**
+   * Merge raw OCR entries into a buffer, combining examples that
+   * span multiple lines.
+   *
+   * @param {Array<{definition:string,example:string}>} inputData - Newly extracted data.
+   * @param {Array<{definition:string,example:string}>} buf - Buffer to append to.
+   * @returns {Array<{definition:string,example:string}>} Updated buffer.
+   */
   processRawData(inputData, buf) {
     for (const item of inputData) {
       const { definition, example } = item
@@ -23,6 +34,12 @@ export class DataProcessor {
     return buf
   }
 
+  /**
+   * Clean up and filter raw entries to prepare them for output.
+   *
+   * @param {Array<{definition:string,example:string}>} inputData - Raw OCR results.
+   * @returns {Promise<Array<{definition:string,example:string}>>} Cleaned entries.
+   */
   async processExtractedData(inputData) {
     const processedData = []
 
@@ -41,6 +58,12 @@ export class DataProcessor {
     return processedData
   }
 
+  /**
+   * Normalize the definition text extracted from the PDF.
+   *
+   * @param {string} def - Raw definition string.
+   * @returns {string} Cleaned definition.
+   */
   processDefinition(def) {
     if (!def) return ''
 
@@ -79,6 +102,12 @@ export class DataProcessor {
     return processed.trim()
   }
 
+  /**
+   * Normalize the example sentence or list.
+   *
+   * @param {string} example - Raw example text.
+   * @returns {string} Cleaned example.
+   */
   processExample(example) {
     if (!example) return ''
 
@@ -146,6 +175,13 @@ export class DataProcessor {
     return processed.trim()
   }
 
+  /**
+   * Apply a set of textual tweaks that are easier to perform
+   * programmatically than by hand.
+   *
+   * @param {string} def - Input definition text.
+   * @returns {string} Tweaked definition text.
+   */
   applyCosmeticFixes(def) {
     return def
       .replace(/raus\(heraus/, 'raus- (heraus')
@@ -160,6 +196,11 @@ export class DataProcessor {
       )
   }
 
+  /**
+   * Retrieve the current git version string for inclusion in outputs.
+   *
+   * @returns {Promise<string>} Git describe output or 'unknown'.
+   */
   async getGitVersion() {
     return new Promise(resolve => {
       const git = spawn('git', ['describe', '--always', '--dirty'], {
@@ -196,6 +237,13 @@ export class DataProcessor {
     })
   }
 
+  /**
+   * Create an HTML table for a single page or for the combined dataset.
+   *
+   * @param {Array<{definition:string,example:string}>} data - Cleaned entries.
+   * @param {string|number} page - Page number or 'all'.
+   * @returns {Promise<string>} Generated HTML document.
+   */
   async generateHTML(data, page) {
     const gitVersion = await this.getGitVersion()
     const generatedAt = new Date().toLocaleString('en-US', {
@@ -283,6 +331,13 @@ using this in any commercial capacity.
     return html
   }
 
+  /**
+   * Create CSV output from processed vocabulary entries.
+   *
+   * @param {Array<{definition:string,example:string}>} data - Cleaned entries.
+   * @param {string|number} page - Page number or 'all'.
+   * @returns {Promise<string>} CSV content.
+   */
   async generateCSV(data, page) {
     const gitVersion = await this.getGitVersion()
     const generatedAt = new Date().toLocaleString('en-US', {

--- a/src/processors/image-processor.js
+++ b/src/processors/image-processor.js
@@ -4,10 +4,21 @@ import { CONFIG } from '../config.js'
 import { fileExists, padPageNumber } from '../utils/fs.js'
 
 export class ImageProcessor {
+  /**
+   * Utility for cropping and annotating page images.
+   */
   constructor() {
     this.outputDir = CONFIG.OUTPUT_DIR
   }
 
+  /**
+   * Extract raw pixel data for a column on the page.
+   *
+   * @param {string} imagePath - Path to the page image.
+   * @param {number} pageNum - Page number for error reporting.
+   * @param {'l'|'r'} column - Column identifier.
+   * @returns {Promise<{data:Buffer,info:import('sharp').OutputInfo}>} Raw pixel info.
+   */
   async getColumnRawPixels(imagePath, pageNum, column) {
     const paddedPage = padPageNumber(pageNum)
     const columnConfig = column === 'l' ? CONFIG.LEFT_COLUMN : CONFIG.RIGHT_COLUMN
@@ -34,6 +45,17 @@ export class ImageProcessor {
     }
   }
 
+  /**
+   * Crop a rectangular region from an image and save it to disk.
+   *
+   * @param {string} imagePath - Source image.
+   * @param {number} x - X offset.
+   * @param {number} y - Y offset.
+   * @param {number} width - Width of crop.
+   * @param {number} height - Height of crop.
+   * @param {string} outputPath - Destination PNG path.
+   * @returns {Promise<string>} Path of the written file.
+   */
   async cropRegion(imagePath, x, y, width, height, outputPath) {
     try {
       await sharp(imagePath)
@@ -45,6 +67,14 @@ export class ImageProcessor {
     }
   }
 
+  /**
+   * Overlay semi-transparent rectangles on an image to highlight regions.
+   *
+   * @param {string} imagePath - Source image path.
+   * @param {string} outputPath - Destination file for the annotated image.
+   * @param {Array<{x0:number,y0:number,x1:number,y1:number}>} rectangles - Areas to highlight.
+   * @returns {Promise<string>} Path to the annotated image.
+   */
   async annotateImage(imagePath, outputPath, rectangles) {
     try {
       // Read the input image into a buffer to avoid potential file locking/path conflicts
@@ -90,6 +120,12 @@ export class ImageProcessor {
     }
   }
 
+  /**
+   * Remove a temporary file if it exists.
+   *
+   * @param {string} filePath - File to delete.
+   * @returns {Promise<void>} Resolves when deletion attempted.
+   */
   async cleanup(filePath) {
     try {
       await fs.unlink(filePath)

--- a/src/processors/pdf-converter.js
+++ b/src/processors/pdf-converter.js
@@ -6,7 +6,10 @@ import { CONFIG } from '../config.js'
 import { fileExists, padPageNumber } from '../utils/fs.js'
 
 /**
- * Generate PNG filename based on PDF filename
+ * Generate the PNG filename for a given page number.
+ *
+ * @param {number} pageNum - Page number (1-based).
+ * @returns {string} Corresponding PNG file name.
  */
 function generatePngFilename(pageNum) {
   const baseName = path.basename(CONFIG.PDF_FILE, '.pdf')
@@ -22,13 +25,21 @@ function generatePngFilename(pageNum) {
  * the available CPU cores for a significant speed-up on multicore hosts.
  */
 export class PDFConverter {
+  /**
+   * Create a new PDFConverter instance.
+   * Stores configuration values and lazily loads the PDF document.
+   */
   constructor() {
     this.pdfFile = CONFIG.PDF_FILE
     this.outputDir = CONFIG.OUTPUT_DIR
     this._doc = null // Lazy-loaded MuPDF document
   }
 
-  /** Lazily open the document (only once) */
+  /**
+   * Lazily open the PDF document so it is loaded only once.
+   *
+   * @returns {Promise<mupdf.PDFDocument>} The opened MuPDF document.
+   */
   async _getDocument() {
     if (this._doc) return this._doc
     const pdfBuffer = await fs.readFile(this.pdfFile)
@@ -109,7 +120,12 @@ export class PDFConverter {
     console.log('PDF conversion completed (MuPDF.js).')
   }
 
-  /** Path helper (unchanged) */
+  /**
+   * Build the path to a previously rendered PNG page image.
+   *
+   * @param {number} pageNum - Page number (1-based).
+   * @returns {Promise<string>} Absolute path to the PNG image.
+   */
   async getPageImagePath(pageNum) {
     const paddedPage = padPageNumber(pageNum)
     const imagePath = `${this.outputDir}/${generatePngFilename(pageNum)}`

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -1,6 +1,12 @@
 import { promises as fs } from 'fs'
 import { dirname } from 'path'
 
+/**
+ * Ensure that the directory for the given file path exists.
+ *
+ * @param {string} path - Path whose directory should be created.
+ * @returns {Promise<void>} Resolves when the directory exists.
+ */
 export async function ensureDir(path) {
   try {
     await fs.mkdir(dirname(path), { recursive: true })
@@ -11,6 +17,12 @@ export async function ensureDir(path) {
   }
 }
 
+/**
+ * Test whether a file exists on disk.
+ *
+ * @param {string} path - Path to the file.
+ * @returns {Promise<boolean>} True when the file is accessible.
+ */
 export async function fileExists(path) {
   try {
     await fs.access(path)
@@ -20,16 +32,35 @@ export async function fileExists(path) {
   }
 }
 
+/**
+ * Read and parse a JSON file.
+ *
+ * @param {string} path - File location.
+ * @returns {Promise<any>} Parsed JSON data.
+ */
 export async function readJSON(path) {
   const content = await fs.readFile(path, 'utf8')
   return JSON.parse(content)
 }
 
+/**
+ * Write JSON data to a file, creating directories when necessary.
+ *
+ * @param {string} path - Destination path.
+ * @param {any} data - Data to be serialized.
+ * @returns {Promise<void>} Resolves when the file is written.
+ */
 export async function writeJSON(path, data) {
   await ensureDir(path)
   await fs.writeFile(path, JSON.stringify(data, null, 2))
 }
 
+/**
+ * Format page numbers as three-digit strings.
+ *
+ * @param {number} num - Page number to format.
+ * @returns {string} Zero-padded representation.
+ */
 export function padPageNumber(num) {
   return num.toString().padStart(3, '0')
 }

--- a/test/page-42.test.js
+++ b/test/page-42.test.js
@@ -15,6 +15,8 @@ describe(
   {
     // Longer timeout for processing a page, especially on slower machines or in CI
     timeout: 60000,
+    // Skip this integration test when running a light test suite (e.g. in CI)
+    skip: process.env.LIGHT_TESTS === 'true' || process.env.LIGHT_TESTS === '1',
   },
   () => {
     before(async t => {


### PR DESCRIPTION
## Summary
- skip the heavy page-42 integration test when `LIGHT_TESTS` is set
- add `test:ci` script that enables the light tests
- update documentation with the new script
- run lighter tests in the CI workflow
- prevent CLI auto-execution when `src/index.js` is imported

## Testing
- `npm run lint`
- `npm test`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_684ea2722758832496a312889c74cf4a